### PR TITLE
feat(streaks) leaderboard + streaks count

### DIFF
--- a/src/commands/zen/leaderboard.ts
+++ b/src/commands/zen/leaderboard.ts
@@ -68,8 +68,8 @@ export default {
       const time =
         ((interaction.options.get('time')?.value as string) || undefined) ??
         'alltime'
-      const userNb = interaction.options.get('user_nb')?.value as number | 10
-      const leaderboardEntries = await getLeaderboard(time, userNb)
+        const userNb = (interaction.options.get('user_nb')?.value as number | 10) || 10
+        const leaderboardEntries = await getLeaderboard(time, userNb)
       if (leaderboardEntries.length === 0) {
         interaction.reply('No one has said "zen" yet!')
         return

--- a/src/commands/zen/leaderboard.ts
+++ b/src/commands/zen/leaderboard.ts
@@ -68,8 +68,9 @@ export default {
       const time =
         ((interaction.options.get('time')?.value as string) || undefined) ??
         'alltime'
-        const userNb = (interaction.options.get('user_nb')?.value as number | 10) || 10
-        const leaderboardEntries = await getLeaderboard(time, userNb)
+      const userNb =
+        (interaction.options.get('user_nb')?.value as number | 10) || 10
+      const leaderboardEntries = await getLeaderboard(time, userNb)
       if (leaderboardEntries.length === 0) {
         interaction.reply('No one has said "zen" yet!')
         return

--- a/src/commands/zen/streaks.ts
+++ b/src/commands/zen/streaks.ts
@@ -70,8 +70,7 @@ export default {
   async execute(interaction) {
     try {
       const hidden = interaction.options.get('hidden')?.value as boolean
-      const userNb =
-        (interaction.options.get('user_nb')?.value as number | 10) || 10
+      const userNb = (interaction.options.get('user_nb')?.value as number | 10) || 10
       const leaderboardEntries = await getStreakLeaderboard(userNb)
       if (leaderboardEntries.length === 0) {
         interaction.reply('No one has any streaks yet!')

--- a/src/commands/zen/streaks.ts
+++ b/src/commands/zen/streaks.ts
@@ -1,0 +1,98 @@
+import { SlashCommandBuilder, EmbedBuilder } from '@discordjs/builders'
+
+import zenCountSchema from '../../schemas/zenCountSchema'
+import { Command } from '../../type'
+
+const updateStreaks = async () => {
+  const users = await zenCountSchema.find({})
+  const currentTime = new Date().getTime()
+  const oneHourOneMinuteAgo = new Date(currentTime - 61 * 60 * 1000)
+
+  for (const user of users) {
+    if (user.lastMessageTime.getTime() < oneHourOneMinuteAgo) {
+      user.streak = 0
+      await user.save()
+    }
+  }
+}
+
+const getStreakLeaderboard = async (
+  userNb: number,
+): Promise<Array<{ name: string; value: string }>> => {
+  await updateStreaks()
+
+  const results = await zenCountSchema
+    .find({ streak: { $gt: 0 } })
+    .sort({ streak: -1 })
+    .limit(userNb)
+    .exec()
+
+  return results.map((result) => {
+    const streak = result.streak
+    let emoji = ''
+
+    if (streak >= 6) {
+      emoji = '🔥'
+    } else if (streak >= 3) {
+      emoji = '👨‍🚒'
+    } else {
+      emoji = '👃'
+    }
+
+    return {
+      name: `${emoji} ${streak} ${streak === 1 ? 'streak' : 'streaks'}`,
+      value: `<@${result._id}> `,
+      inline: true,
+    }
+  })
+}
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName('streak')
+    .setDescription('Show the Streak Leaderboard.')
+    .addNumberOption((option) =>
+      option
+        .setName('user_nb')
+        .setDescription(
+          'The number of users to show in the leaderboard. Min 1, max 20.',
+        )
+        .setRequired(false)
+        .setMaxValue(20)
+        .setMinValue(1),
+    )
+    .addBooleanOption((option) =>
+      option
+        .setName('hidden')
+        .setDescription('Hide the command from other users.')
+        .setRequired(false),
+    ),
+  async execute(interaction) {
+    try {
+      const hidden = interaction.options.get('hidden')?.value as boolean
+      const userNb =
+        (interaction.options.get('user_nb')?.value as number | 10) || 10
+      const leaderboardEntries = await getStreakLeaderboard(userNb)
+      if (leaderboardEntries.length === 0) {
+        interaction.reply('No one has any streaks yet!')
+        return
+      }
+
+      const embed = new EmbedBuilder()
+        .setColor(0x0099ff)
+        .setTitle(
+          '🔥 Streak Leaderboard 🔥' + (userNb === 10 ? '' : ` TOP ${userNb}`),
+        )
+        .setFooter({
+          text: 'Last updated',
+        })
+        .setTimestamp()
+
+      embed.addFields(...leaderboardEntries)
+
+      await interaction.reply({ embeds: [embed], ephemeral: hidden })
+    } catch (error) {
+      console.error('Error getting streak leaderboard:', error)
+    }
+  },
+} as Command

--- a/src/commands/zen/streaks.ts
+++ b/src/commands/zen/streaks.ts
@@ -70,7 +70,8 @@ export default {
   async execute(interaction) {
     try {
       const hidden = interaction.options.get('hidden')?.value as boolean
-      const userNb = (interaction.options.get('user_nb')?.value as number | 10) || 10
+      const userNb =
+        (interaction.options.get('user_nb')?.value as number | 10) || 10
       const leaderboardEntries = await getStreakLeaderboard(userNb)
       if (leaderboardEntries.length === 0) {
         interaction.reply('No one has any streaks yet!')

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,6 +9,7 @@ export const NOSE = [
   'nez',
   'zen',
   'nose',
+  'noz',
   '👃',
   '👃🏻',
   '👃🏼',

--- a/src/schemas/zenCountSchema.ts
+++ b/src/schemas/zenCountSchema.ts
@@ -25,6 +25,11 @@ const zenCountSchema = new Schema({
     required: true,
     default: new Date(0),
   },
+  streak: {
+    type: Number,
+    required: true,
+    default: 0,
+  },
 })
 
 const name = 'ZenCountSchema'


### PR DESCRIPTION
This PR introduces a new feature to the Discord bot—streak tracking! Users can now view a leaderboard of streaks, with emoji-based rankings, including 🔥 for high streaks, 👨‍🚒 for moderate streaks, and 👃 for lower streaks. The streaks are automatically updated for users who haven't sent a message in over an hour and one minute, ensuring accuracy. 