### PR TITLE
feat(best_streaks)add a best streak counter that display the best str…

### DIFF
--- a/src/events/message.ts
+++ b/src/events/message.ts
@@ -38,6 +38,7 @@ const handleNezMessage = async (message: Message): Promise<void> => {
         { _id: message.author.id },
         {
           $inc: { streak: 1 },
+          $max: { bestStreak: userDoc.streak + 1 },
         },
         { upsert: true, new: true },
       )

--- a/src/schemas/zenCountSchema.ts
+++ b/src/schemas/zenCountSchema.ts
@@ -30,6 +30,11 @@ const zenCountSchema = new Schema({
     required: true,
     default: 0,
   },
+  bestStreak: {
+    type: Number,
+    required: true,
+    default: 0,
+  },
 })
 
 const name = 'ZenCountSchema'


### PR DESCRIPTION
Implementation of a bestStreak counter, which keeps track of users' highest streaks. Now, when a user achieves a new highest streak, their bestStreak is updated to reflect this achievement, and show in the leaderboard streak with the /streak command.

The previous issue with streak resets should be gone, the logic for updating streaks to 0 changed a bit, to avoid users suffering unfair streak losses. The time window should be enough now.